### PR TITLE
Switch liveness probe from http to tcp socket

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -176,14 +176,14 @@ spec:
             containerPort: {{ .Values.httpPort }}
             protocol: TCP
         livenessProbe:
-          httpGet:
-            path: /status
+          tcpSocket:
             port: http
+          initialDelaySeconds: 30
           timeoutSeconds: 10
         readinessProbe:
-          httpGet:
-            path: /status
+          tcpSocket:
             port: http
+          initialDelaySeconds: 30
           timeoutSeconds: 10
         resources:
           {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Use the tcp socket check to avoid the flooding http status logs in OCP console.

Also add the initialDelaySeconds to avoid check too soon at start up.

Signed-off-by: Wayne Sun <gsun@redhat.com>