### PR TITLE
Update github checkout action to v3

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,5 +12,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable


### PR DESCRIPTION
The v2 with Nodejs 12 is deprecated